### PR TITLE
S3 extension support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,17 @@ cargo build -p rust-sdk --target wasm32-wasi --release
 ```sh
 npm run dev
 ```
+
+##  Testing Blockless extensions
+
+### S3
+
+First run localstack locally:
+```sh
+docker run \
+  --rm -it \
+  -e EXTRA_CORS_ALLOWED_ORIGINS="http://localhost:8080" \
+  -p 4566:4566 \
+  -p 4510-4559:4510-4559 \
+  localstack/localstack
+```

--- a/bls-runtime-wasm/Cargo.lock
+++ b/bls-runtime-wasm/Cargo.lock
@@ -55,10 +55,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "attohttpc"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
+dependencies = [
+ "http",
+ "log",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "aws-creds"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3776743bb68d4ad02ba30ba8f64373f1be4e082fe47651767171ce75bb2f6cf5"
+dependencies = [
+ "attohttpc",
+ "dirs",
+ "log",
+ "quick-xml",
+ "rust-ini",
+ "serde",
+ "thiserror",
+ "time 0.3.30",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056557a61427d0e5ba29dd931031c8ffed4ee7a550e7cd55692a9d8deb0a9dba"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "backtrace"
@@ -83,6 +122,12 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
@@ -94,10 +139,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bls-common"
 version = "0.1.0"
 dependencies = [
+ "aws-creds",
  "reqwest",
+ "rust-s3",
  "serde",
  "serde_json",
  "serde_qs",
@@ -239,6 +295,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
 name = "cxx"
 version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +392,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -328,10 +413,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "encoding_rs"
@@ -447,6 +569,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +632,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -683,6 +830,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.104",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -783,6 +947,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +973,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro-error"
@@ -871,12 +1051,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -906,7 +1116,7 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -959,6 +1169,45 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.104",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2ac5ff6acfbe74226fa701b5ef793aaa054055c13ebb7060ad36942956e027"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "aws-creds",
+ "aws-region",
+ "base64 0.13.1",
+ "bytes",
+ "cfg-if 1.0.0",
+ "hex",
+ "hmac",
+ "http",
+ "log",
+ "maybe-async",
+ "md5",
+ "percent-encoding",
+ "quick-xml",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "thiserror",
+ "time 0.3.30",
+ "url",
 ]
 
 [[package]]
@@ -1096,6 +1345,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae1a47186c03a32177042e55dbc5fd5aee900b8e0069a8d70fba96a9375cd012"
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1449,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1255,10 +1521,30 @@ dependencies = [
  "libc",
  "standback",
  "stdweb",
- "time-macros",
+ "time-macros 0.1.1",
  "version_check",
  "winapi",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros 0.2.15",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
@@ -1268,6 +1554,15 @@ checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
 dependencies = [
  "proc-macro-hack",
  "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -1370,6 +1665,12 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"
@@ -1704,7 +2005,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1afdec83c62d22bf7110b83d662a08f708332fd728a213399919a045a1061d4"
 dependencies = [
  "byteorder",
- "time",
+ "time 0.2.27",
  "wasmer",
  "wasmer-derive",
  "wasmer-types",

--- a/bls-runtime-wasm/Cargo.lock
+++ b/bls-runtime-wasm/Cargo.lock
@@ -29,6 +29,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -55,48 +64,62 @@ dependencies = [
 ]
 
 [[package]]
-name = "attohttpc"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
-dependencies = [
- "http",
- "log",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "aws-creds"
-version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3776743bb68d4ad02ba30ba8f64373f1be4e082fe47651767171ce75bb2f6cf5"
+name = "aws-sigv4"
+version = "0.0.0-smithy-rs-head"
+source = "git+https://github.com/blocklessnetwork/aws-sigv4-wasm32?rev=61dd490d#61dd490db3886ae458897e2a3583bac5924e62d2"
 dependencies = [
- "attohttpc",
- "dirs",
- "log",
- "quick-xml",
- "rust-ini",
- "serde",
- "thiserror",
+ "aws-smithy-http",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "sha2",
  "time 0.3.30",
- "url",
+ "tracing",
+ "wasm-timer",
 ]
 
 [[package]]
-name = "aws-region"
-version = "0.25.3"
+name = "aws-smithy-http"
+version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056557a61427d0e5ba29dd931031c8ffed4ee7a550e7cd55692a9d8deb0a9dba"
+checksum = "54cdcf365d8eee60686885f750a34c190e513677db58bbc466c44c588abf4199"
 dependencies = [
- "thiserror",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.56.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90dbc8da2f6be461fa3c1906b20af8f79d14968fe47f2b7d29d086f62a51728"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "serde",
+ "time 0.3.30",
 ]
 
 [[package]]
@@ -122,15 +145,19 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bitflags"
@@ -151,12 +178,13 @@ dependencies = [
 name = "bls-common"
 version = "0.1.0"
 dependencies = [
- "aws-creds",
+ "aws-sigv4",
+ "http",
  "reqwest",
- "rust-s3",
  "serde",
  "serde_json",
  "serde_qs",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -216,6 +244,16 @@ name = "bytes"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cc"
@@ -398,7 +436,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -424,36 +461,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
-name = "dlv-list"
-version = "0.3.0"
+name = "either"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encoding_rs"
@@ -521,12 +538,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -534,6 +567,34 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.36",
+]
 
 [[package]]
 name = "futures-sink"
@@ -553,10 +614,16 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -764,6 +831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,6 +888,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,23 +914,6 @@ checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "maybe-async"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.104",
-]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -947,13 +1016,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
 
 [[package]]
-name = "ordered-multimap"
-version = "0.4.3"
+name = "outref"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
- "dlv-list",
- "hashbrown",
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1051,16 +1141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,15 +1159,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
+name = "regex"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
 dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "region"
@@ -1116,7 +1214,7 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.4",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -1169,45 +1267,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.104",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if 1.0.0",
- "ordered-multimap",
-]
-
-[[package]]
-name = "rust-s3"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2ac5ff6acfbe74226fa701b5ef793aaa054055c13ebb7060ad36942956e027"
-dependencies = [
- "async-trait",
- "attohttpc",
- "aws-creds",
- "aws-region",
- "base64 0.13.1",
- "bytes",
- "cfg-if 1.0.0",
- "hex",
- "hmac",
- "http",
- "log",
- "maybe-async",
- "md5",
- "percent-encoding",
- "quick-xml",
- "serde",
- "serde_derive",
- "sha2",
- "thiserror",
- "time 0.3.30",
- "url",
 ]
 
 [[package]]
@@ -1533,7 +1592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
- "itoa",
  "powerfmt",
  "serde",
  "time-core",
@@ -1738,6 +1796,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,6 +1906,21 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "wasmer"

--- a/bls-runtime-wasm/src/lib.rs
+++ b/bls-runtime-wasm/src/lib.rs
@@ -500,13 +500,11 @@ impl Blockless {
                     .clone()
                     .into();
 
-                let s3_call_response = match s3_command.exec(&mut static_ctx_ref.data_mut().s3_client) {
-                    Ok(response) => Ok(response),
-                    Err(err) => {
+                let s3_call_response = s3_command.exec(&mut static_ctx_ref.data_mut().s3_client).await
+                    .map_err(|err| {
                         console_error!("Error while running s3_command.exec: {}", err);
-                        Err(err.to_string())
-                    }
-                };
+                        err
+                    });
                 let data = serde_json::to_vec(&s3_call_response).expect("failed to serialize module call response");
                 let result_ptr = utils::encode_data_to_memory(&memory_obj, &alloc_func, &data);
 

--- a/bls-runtime-wasm/src/lib.rs
+++ b/bls-runtime-wasm/src/lib.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 pub mod fs;
 pub mod utils;
 
-use bls_common::{http::{HttpResponse, HttpRequest}, ipfs::{IPFSCommand, client::IPFSClient}};
+use bls_common::{http::{HttpResponse, HttpRequest}, ipfs::{IPFSCommand, client::IPFSClient}, s3::{S3Client, S3Command}};
 
 use serde::{Deserialize, Serialize};
 use js_sys::{Map, Object, Reflect, WebAssembly};
@@ -267,11 +267,13 @@ impl Blockless {
             exports: Arc<Mutex<RefCell<Option<Exports>>>>,
             permissions: Vec<String>,
             ipfs_client: IPFSClient,
+            s3_client: S3Client,
         }
         let env = FunctionEnv::new(&mut self.store, Env {
             exports: self.exports.clone(),
             permissions: self.permissions.clone(),
             ipfs_client: IPFSClient::default(),
+            s3_client: S3Client::default(),
         });
 
         fn host_log(ctx: FunctionEnvMut<Env>, ptr: u32, len: u32) {
@@ -395,8 +397,6 @@ impl Blockless {
             let ipfs_command = serde_json::from_slice::<IPFSCommand>(&buf).expect("failed to deserialize http request");
             console_log!("ipfs_call: ipfs_request called: {}", ipfs_command); // TODO trace
 
-            // TODO any IPFS permissions?
-
             let boxed_ctx_ref: Box<FunctionEnvMut<Env>> = Box::new(ctx);
             let static_ctx_ref: &'static mut FunctionEnvMut<Env> = unsafe { std::mem::transmute(Box::leak(boxed_ctx_ref)) };
             wasm_bindgen_futures::spawn_local(async move {
@@ -448,11 +448,87 @@ impl Blockless {
             0
         }
 
+        fn s3_call(ctx: FunctionEnvMut<Env>, ptr: u32, len: u32, callback_id: u64) -> u32 {
+            let exports = {
+                let binding = ctx.data().exports.lock().unwrap();
+                let exports = binding.borrow().to_owned().expect("exports should have been set");
+                exports
+            };
+            let memory = exports.get_memory("memory").expect("memory export wasn't found");
+
+            let mut buf = vec![0u8; len as usize];
+            memory.view(&ctx.as_store_ref()).read(ptr as u64, &mut buf).expect("failed to read memory");
+
+            // required to write data back to guest
+            // TODO: find another way to do this without manually allocating memory?
+            let alloc_func = exports.get_function("alloc").expect("alloc function not found");
+            let s3_callback = exports.get_function("s3_callback").expect("s3_callback function not found");
+
+            let buf_str = std::str::from_utf8(&buf).unwrap();
+            console_log!("s3_request successfully read data: {:?}", buf_str);
+
+            let s3_command = serde_json::from_slice::<S3Command>(&buf).expect("failed to deserialize http request");
+            console_log!("s3_call: s3_request called: {}", s3_command); // TODO trace
+
+            // TODO: we may not need to use async/await here since these are all blocking calls
+
+            let boxed_ctx_ref: Box<FunctionEnvMut<Env>> = Box::new(ctx);
+            let static_ctx_ref: &'static mut FunctionEnvMut<Env> = unsafe { std::mem::transmute(Box::leak(boxed_ctx_ref)) };
+            wasm_bindgen_futures::spawn_local(async move {
+                let memory = exports.get_memory("memory").expect("memory export wasn't found");
+
+                // NOTE: convert callbacks to wasm_bindgen types - since return values do not seem to work!
+                let memory_obj: WebAssembly::Memory = exports
+                    .get_extern("memory")
+                    .expect("memory export wasn't found")
+                    .to_vm_extern()
+                    .as_jsvalue(&static_ctx_ref.as_store_ref())
+                    .clone()
+                    .into();
+                let s3_callback: js_sys::Function = exports
+                    .get_function("s3_callback")
+                    .expect("s3_callback function not found")
+                    .to_vm_extern()
+                    .as_jsvalue(&static_ctx_ref.as_store_ref())
+                    .clone()
+                    .into();
+                let alloc_func: js_sys::Function = exports
+                    .get_function("alloc")
+                    .expect("alloc function not found")
+                    .to_vm_extern()
+                    .as_jsvalue(&static_ctx_ref.as_store_ref())
+                    .clone()
+                    .into();
+
+                let s3_call_response = match s3_command.exec(&mut static_ctx_ref.data_mut().s3_client) {
+                    Ok(response) => Ok(response),
+                    Err(err) => {
+                        console_error!("Error while running s3_command.exec: {}", err);
+                        Err(err.to_string())
+                    }
+                };
+                let data = serde_json::to_vec(&s3_call_response).expect("failed to serialize module call response");
+                let result_ptr = utils::encode_data_to_memory(&memory_obj, &alloc_func, &data);
+
+                match s3_callback.call2(&JsValue::undefined(), &JsValue::from(result_ptr), &JsValue::from(callback_id)) {
+                    Ok(_val) => console_log!("s3_callback called successfully"),
+                    Err(err) => console_error!("Error while running s3_callback {}", err.as_string().unwrap_or_default()),
+                };
+
+                // manually deallocate memory
+                unsafe {
+                    let _reclaimed = Box::from_raw(static_ctx_ref);
+                }
+            });
+            0
+        }
+
         let imports = imports! {
             "blockless" => {
                 "host_log" => Function::new_typed_with_env(&mut self.store, &env, host_log),
                 "http_call" => Function::new_typed_with_env(&mut self.store, &env, http_call),
                 "ipfs_call" => Function::new_typed_with_env(&mut self.store, &env, ipfs_call),
+                "s3_call" => Function::new_typed_with_env(&mut self.store, &env, s3_call),
             },
         };
 

--- a/crates/bls-common/Cargo.lock
+++ b/crates/bls-common/Cargo.lock
@@ -18,38 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
+name = "aho-corasick"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.37",
-]
-
-[[package]]
-name = "attohttpc"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
-dependencies = [
- "http",
- "log",
- "serde",
- "serde_json",
- "url",
+ "memchr",
 ]
 
 [[package]]
@@ -59,29 +33,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "aws-creds"
-version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3776743bb68d4ad02ba30ba8f64373f1be4e082fe47651767171ce75bb2f6cf5"
+name = "aws-sigv4"
+version = "0.0.0-smithy-rs-head"
+source = "git+https://github.com/blocklessnetwork/aws-sigv4-wasm32?rev=61dd490d#61dd490db3886ae458897e2a3583bac5924e62d2"
 dependencies = [
- "attohttpc",
- "dirs",
- "log",
- "quick-xml",
- "rust-ini",
- "serde",
- "thiserror",
+ "aws-smithy-http",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "sha2",
  "time",
- "url",
+ "tracing",
+ "wasm-timer",
 ]
 
 [[package]]
-name = "aws-region"
-version = "0.25.3"
+name = "aws-smithy-http"
+version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056557a61427d0e5ba29dd931031c8ffed4ee7a550e7cd55692a9d8deb0a9dba"
+checksum = "54cdcf365d8eee60686885f750a34c190e513677db58bbc466c44c588abf4199"
 dependencies = [
- "thiserror",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.56.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90dbc8da2f6be461fa3c1906b20af8f79d14968fe47f2b7d29d086f62a51728"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "serde",
+ "time",
 ]
 
 [[package]]
@@ -101,15 +102,19 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bitflags"
@@ -130,13 +135,14 @@ dependencies = [
 name = "bls-common"
 version = "0.1.0"
 dependencies = [
- "aws-creds",
+ "aws-sigv4",
+ "http",
  "reqwest",
- "rust-s3",
  "serde",
  "serde_json",
  "serde_qs",
  "tokio",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -150,6 +156,16 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cc"
@@ -208,7 +224,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -223,30 +238,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
+name = "either"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encoding_rs"
@@ -273,12 +268,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -286,6 +297,34 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -305,10 +344,16 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -319,17 +364,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -362,9 +396,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -466,6 +497,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -507,23 +547,6 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "maybe-async"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -568,6 +591,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "num_cpus"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,13 +635,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "ordered-multimap"
-version = "0.4.3"
+name = "outref"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
- "dlv-list",
- "hashbrown",
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
 ]
 
 [[package]]
@@ -609,7 +658,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.8",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -659,16 +722,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -696,15 +749,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
@@ -712,7 +783,7 @@ version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78fdbab6a7e1d7b13cc8ff10197f47986b41c639300cc3c8158cac7847c9bbef"
 dependencies = [
- "base64 0.21.4",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -740,45 +811,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
-]
-
-[[package]]
-name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
-
-[[package]]
-name = "rust-s3"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2ac5ff6acfbe74226fa701b5ef793aaa054055c13ebb7060ad36942956e027"
-dependencies = [
- "async-trait",
- "attohttpc",
- "aws-creds",
- "aws-region",
- "base64 0.13.1",
- "bytes",
- "cfg-if",
- "hex",
- "hmac",
- "http",
- "log",
- "maybe-async",
- "md5",
- "percent-encoding",
- "quick-xml",
- "serde",
- "serde_derive",
- "sha2",
- "thiserror",
- "time",
- "url",
 ]
 
 [[package]]
@@ -816,7 +848,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn",
 ]
 
 [[package]]
@@ -916,17 +948,6 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
@@ -974,7 +995,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn",
 ]
 
 [[package]]
@@ -984,7 +1005,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
- "itoa",
  "powerfmt",
  "serde",
  "time-core",
@@ -1032,7 +1052,7 @@ dependencies = [
  "libc",
  "mio",
  "num_cpus",
- "parking_lot",
+ "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.4",
@@ -1048,7 +1068,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn",
 ]
 
 [[package]]
@@ -1079,7 +1099,19 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1151,6 +1183,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,7 +1224,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1220,7 +1258,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.37",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1230,6 +1268,21 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot 0.11.2",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/crates/bls-common/Cargo.lock
+++ b/crates/bls-common/Cargo.lock
@@ -18,10 +18,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "attohttpc"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
+dependencies = [
+ "http",
+ "log",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "aws-creds"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3776743bb68d4ad02ba30ba8f64373f1be4e082fe47651767171ce75bb2f6cf5"
+dependencies = [
+ "attohttpc",
+ "dirs",
+ "log",
+ "quick-xml",
+ "rust-ini",
+ "serde",
+ "thiserror",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056557a61427d0e5ba29dd931031c8ffed4ee7a550e7cd55692a9d8deb0a9dba"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "backtrace"
@@ -40,6 +101,12 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
@@ -51,10 +118,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bls-common"
 version = "0.1.0"
 dependencies = [
+ "aws-creds",
  "reqwest",
+ "rust-s3",
  "serde",
  "serde_json",
  "serde_qs",
@@ -103,6 +181,72 @@ name = "core-foundation-sys"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "encoding_rs"
@@ -168,6 +312,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,12 +362,30 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -326,6 +509,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,6 +593,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,7 +620,7 @@ checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.3.5",
  "smallvec",
  "windows-targets",
 ]
@@ -434,12 +644,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -453,6 +679,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
@@ -461,12 +696,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall 0.2.16",
+ "thiserror",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78fdbab6a7e1d7b13cc8ff10197f47986b41c639300cc3c8158cac7847c9bbef"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -494,6 +740,45 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2ac5ff6acfbe74226fa701b5ef793aaa054055c13ebb7060ad36942956e027"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "aws-creds",
+ "aws-region",
+ "base64 0.13.1",
+ "bytes",
+ "cfg-if",
+ "hex",
+ "hmac",
+ "http",
+ "log",
+ "maybe-async",
+ "md5",
+ "percent-encoding",
+ "quick-xml",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "thiserror",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -531,7 +816,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -566,6 +851,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -610,6 +906,23 @@ checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -661,7 +974,36 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
+]
+
+[[package]]
+name = "time"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -706,7 +1048,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -754,6 +1096,12 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"
@@ -838,7 +1186,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
  "wasm-bindgen-shared",
 ]
 
@@ -872,7 +1220,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/crates/bls-common/Cargo.toml
+++ b/crates/bls-common/Cargo.toml
@@ -10,7 +10,9 @@ default = ["use-wasm-bindgen"]
 use-wasm-bindgen = []
 
 [dependencies]
-reqwest = { version = "0.11.20", default-features = false, features = ["multipart"]}
+reqwest = { version = "0.11.20", default-features = false, features = ["multipart"] }
+aws-creds = { version = "0.34.1", default-features = false, features = ["http-credentials"] }
+rust-s3 = { version = "0.33.0", default-features = false, features = ["sync"] }
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 serde_qs = "0.12.0"

--- a/crates/bls-common/Cargo.toml
+++ b/crates/bls-common/Cargo.toml
@@ -10,9 +10,10 @@ default = ["use-wasm-bindgen"]
 use-wasm-bindgen = []
 
 [dependencies]
-reqwest = { version = "0.11.20", default-features = false, features = ["multipart"] }
-aws-creds = { version = "0.34.1", default-features = false, features = ["http-credentials"] }
-rust-s3 = { version = "0.33.0", default-features = false, features = ["sync"] }
+http = "0.2.9"
+reqwest = { version = "0.11.20", default-features = false, features = ["multipart", "json"] }
+aws-sigv4 = { git = "https://github.com/blocklessnetwork/aws-sigv4-wasm32", rev = "61dd490d" }
+wasm-timer = "0.2.5"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"
 serde_qs = "0.12.0"

--- a/crates/bls-common/src/lib.rs
+++ b/crates/bls-common/src/lib.rs
@@ -1,6 +1,7 @@
 /// Declare common structs, serialization, deserialization and functions here;
 /// the `bls-runtime-wasm` and `rust-sdk` will use this crate
 pub mod http;
+pub mod s3;
 pub mod ipfs;
 
 mod macros;

--- a/crates/bls-common/src/s3.rs
+++ b/crates/bls-common/src/s3.rs
@@ -1,0 +1,245 @@
+use crate::impl_display;
+use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use s3::{creds::Credentials, Bucket, BucketConfiguration, Region};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct S3Config {
+  pub access_key: String,
+  pub secret_key: String,
+  pub endpoint: String,
+  pub region: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct S3Client {
+  credentials: Option<Credentials>,
+  region: Option<Region>,
+}
+
+impl S3Client {
+  pub fn set_config(&mut self, config: S3Config) {
+    self.credentials = Some(Credentials::new(
+      Some(&config.access_key),
+      Some(&config.secret_key),
+      None,
+      None,
+      None,
+    ).expect("aws s3 credentials"));
+    self.region = Some(Region::Custom {
+      region: config.region.unwrap_or("us-east-1".to_string()).into(),
+      endpoint: config.endpoint,
+    });
+  }
+
+  fn validate_config(&self) -> Result<(), &'static str> {
+    if self.credentials.is_none() {
+      return Err("credentials not set");
+    }
+    if self.region.is_none() {
+      return Err("region not set");
+    }
+    Ok(())
+  }
+
+  pub fn list(&self, opts: S3ListOpts) -> Result<Vec<S3ListItemResponse>, &'static str> {
+    self.validate_config()?;
+
+    let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
+      .map_err(|e| {
+        println!("list bucket error: {:?}", e);
+        "bucket error"
+      })?;
+    let list = bucket.list(opts.prefix, opts.delimiter)
+      .map_err(|e| {
+        println!("list bucket error: {:?}", e);
+        "list bucket error"
+      })?;
+    let results = list
+      .into_iter()
+      .map(|item| {
+        let item_content = item.contents
+          .into_iter()
+          .map(|c| {
+            S3ListItemResponseContent {
+              last_modified: c.last_modified,
+              e_tag: c.e_tag,
+              storage_class: c.storage_class,
+              key: c.key,
+              size: c.size,
+            }
+          })
+          .collect::<Vec<_>>();
+        S3ListItemResponse {
+          name: item.name,
+          is_truncated: item.is_truncated,
+          prefix: item.prefix,
+          contents: item_content,
+        }
+      })
+      .collect::<Vec<_>>();
+    Ok(results)
+  }
+
+  pub fn create(&self, opts: &S3CreateOpts) -> Result<S3Response, &'static str> {
+    self.validate_config()?;
+ 
+    let bucket_config = BucketConfiguration::default();
+    let create_response = Bucket::create(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone(), bucket_config)
+      .map_err(|e| {
+        println!("create bucket error: {:?}", e);
+        "create bucket error"
+      })?;
+    Ok(S3Response {
+      headers: Default::default(),
+      status_code: create_response.response_code,
+      bytes: create_response.response_text.as_bytes().to_vec(),
+    })
+  }
+
+  pub fn get(&self, opts: &S3GetOpts) -> Result<S3Response, &'static str> {
+    self.validate_config()?;
+ 
+    let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
+      .map_err(|e| {
+        println!("get bucket error: {:?}", e);
+        "bucket error"
+      })?;
+    let get_response = bucket.get_object(&opts.path)
+      .map_err(|e| {
+        println!("get object error: {:?}", e);
+        "get object error"
+      })?;
+    Ok(S3Response {
+      status_code: get_response.status_code(),
+      headers: get_response.headers(),
+      bytes: get_response.to_vec(),
+    })
+  }
+
+  pub fn put(&self, opts: &S3PutOpts) -> Result<S3Response, &'static str> {
+    self.validate_config()?;
+
+    let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
+      .map_err(|e| {
+        println!("put bucket error: {:?}", e);
+        "bucket error"
+      })?;
+    let put_response = bucket.put_object(&opts.path, opts.content.as_slice())
+      .map_err(|e| {
+        println!("put object error: {:?}", e);
+        "put object error"
+      })?;
+    Ok(S3Response {
+      status_code: put_response.status_code(),
+      headers: put_response.headers(),
+      bytes: put_response.to_vec(),
+    })
+  }
+
+  pub fn delete(&self, opts: &S3DeleteOpts) -> Result<S3Response, &'static str> {
+    self.validate_config()?;
+  
+    let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
+      .map_err(|e| {
+        println!("delete bucket error: {:?}", e);
+        "bucket error"
+      })?;
+    let delete_response = bucket.delete_object(&opts.path)
+      .map_err(|e| {
+        println!("delete object error: {:?}", e);
+        "delete object error"
+      })?;
+    Ok(S3Response {
+      status_code: delete_response.status_code(),
+      headers: delete_response.headers(),
+      bytes: delete_response.to_vec(),
+    })
+  }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub enum S3Command {
+  S3SetConfig(S3Config),
+  S3Create(S3CreateOpts),
+  S3List(S3ListOpts),
+  S3Get(S3GetOpts),
+  S3Put(S3PutOpts),
+  S3Delete(S3DeleteOpts),
+}
+impl_display!(S3Command);
+
+impl S3Command {
+  pub fn exec(&self, client: &mut S3Client) -> Result<Vec<u8>, &'static str> {
+    let res = match self {
+      S3Command::S3SetConfig(opts) => serde_json::to_vec(&client.set_config(opts.clone()))
+        .map_err(|_| "failed to serialize response")?,
+      S3Command::S3List(opts) => serde_json::to_vec(&client.list(opts.clone())?)
+        .map_err(|_| "failed to serialize response")?,
+      S3Command::S3Create(opts) => serde_json::to_vec(&client.create(opts)?)
+        .map_err(|_| "failed to serialize response")?,
+      S3Command::S3Get(opts) => serde_json::to_vec(&client.get(opts)?)
+        .map_err(|_| "failed to serialize response")?,
+      S3Command::S3Put(opts) => serde_json::to_vec(&client.put(opts)?)
+        .map_err(|_| "failed to serialize response")?,
+      S3Command::S3Delete(opts) => serde_json::to_vec(&client.delete(opts)?)
+        .map_err(|_| "failed to serialize response")?,
+    };
+    Ok(res)
+  }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct S3ListOpts {
+  pub bucket_name: String,
+  pub prefix: String,
+  pub delimiter: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct S3ListItemResponseContent {
+  pub last_modified: String,
+  pub e_tag: Option<String>,
+  pub storage_class: Option<String>,
+  pub key: String,
+  pub size: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct S3ListItemResponse {
+  pub name: String,
+  pub is_truncated: bool,
+  pub prefix: Option<String>,
+  pub contents: Vec<S3ListItemResponseContent>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct S3CreateOpts {
+  pub bucket_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct S3GetOpts {
+  pub bucket_name: String,
+  pub path: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct S3PutOpts {
+  pub bucket_name: String,
+  pub path: String,
+  pub content: Vec<u8>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct S3DeleteOpts {
+  pub bucket_name: String,
+  pub path: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct S3Response {
+  bytes: Vec<u8>,
+  status_code: u16,
+  headers: HashMap<String, String>,
+}

--- a/crates/bls-common/src/s3.rs
+++ b/crates/bls-common/src/s3.rs
@@ -1,9 +1,14 @@
 use crate::impl_display;
 use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
-use s3::{creds::Credentials, Bucket, BucketConfiguration, Region};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[cfg(feature = "use-wasm-bindgen")]
+use aws_sigv4::http_request::{sign, SigningSettings, SigningParams, SignableRequest, };
+
+#[cfg(feature = "use-wasm-bindgen")]
+use wasm_timer::SystemTime;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
 pub struct S3Config {
   pub access_key: String,
   pub secret_key: String,
@@ -12,155 +17,303 @@ pub struct S3Config {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct S3Client {
-  credentials: Option<Credentials>,
-  region: Option<Region>,
-}
+pub struct S3Client;
 
+#[cfg(feature = "use-wasm-bindgen")]
 impl S3Client {
-  pub fn set_config(&mut self, config: S3Config) {
-    self.credentials = Some(Credentials::new(
-      Some(&config.access_key),
-      Some(&config.secret_key),
-      None,
-      None,
-      None,
-    ).expect("aws s3 credentials"));
-    self.region = Some(Region::Custom {
-      region: config.region.unwrap_or("us-east-1".to_string()).into(),
-      endpoint: config.endpoint,
-    });
-  }
 
-  fn validate_config(&self) -> Result<(), &'static str> {
-    if self.credentials.is_none() {
+  fn sign_request(&self, config: &S3Config, req: &mut http::Request<Vec<u8>>) -> Result<(), &'static str> {
+    if config.access_key.is_empty() || config.secret_key.is_empty(){
       return Err("credentials not set");
     }
-    if self.region.is_none() {
-      return Err("region not set");
-    }
+
+    // fix code in aws-sigv4 crate to convert to/from `OffsetDateTime`
+    let (access_key, secret_key, region) = {
+      (&config.secret_key, &config.access_key, &config.region.clone().unwrap_or("us-east-1".to_string()))
+    };
+    
+    let signing_params = SigningParams::builder()
+      .access_key(&access_key)
+      .secret_key(&secret_key)
+      .region(&region)
+      .service_name("s3")
+      .time(SystemTime::now())
+      .settings(SigningSettings::default())
+      .build()
+      .unwrap();
+
+    let signable_request = SignableRequest::from(&*req);
+    let (signing_instructions, _signature) = sign(signable_request, &signing_params).unwrap().into_parts();
+    signing_instructions.apply_to_request(req);
     Ok(())
   }
 
-  pub fn list(&self, opts: S3ListOpts) -> Result<Vec<S3ListItemResponse>, &'static str> {
-    self.validate_config()?;
+  pub async fn list(&self, opts: S3ListOpts) -> Result<Vec<u8>, &'static str> {
+    // build the request to list objects in the S3 bucket
+    let mut request = http::Request::builder()
+      .method("GET")
+      .uri(&opts.config.endpoint)
+      .header("Accept", "application/json") 
+      .body(Default::default())
+      .unwrap();
 
-    let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
-      .map_err(|e| {
-        println!("list bucket error: {:?}", e);
-        "bucket error"
-      })?;
-    let list = bucket.list(opts.prefix, opts.delimiter)
-      .map_err(|e| {
-        println!("list bucket error: {:?}", e);
-        "list bucket error"
-      })?;
-    let results = list
-      .into_iter()
-      .map(|item| {
-        let item_content = item.contents
-          .into_iter()
-          .map(|c| {
-            S3ListItemResponseContent {
-              last_modified: c.last_modified,
-              e_tag: c.e_tag,
-              storage_class: c.storage_class,
-              key: c.key,
-              size: c.size,
-            }
-          })
-          .collect::<Vec<_>>();
-        S3ListItemResponse {
-          name: item.name,
-          is_truncated: item.is_truncated,
-          prefix: item.prefix,
-          contents: item_content,
-        }
-      })
-      .collect::<Vec<_>>();
-    Ok(results)
+    // sign the request
+    let _ = self.sign_request(&opts.config, &mut request)?;
+
+    // perform the request
+    let reqwest_request = reqwest::Request::try_from(request).unwrap();
+    let response = reqwest::Client::new()
+        .execute(reqwest_request)
+        .await
+        .map_err(|_| "failed to execute request")?;
+
+    if !response.status().is_success() {
+      return Err("failed to get response");
+    }
+
+    let got_text = response.text().await.map_err(|_| "failed to get response text")?;
+    Ok(got_text.as_bytes().to_vec())
+
+    // let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
+    //   .map_err(|e| {
+    //     println!("list bucket error: {:?}", e);
+    //     "bucket error"
+    //   })?;
+    // let list = bucket.list(opts.prefix, opts.delimiter)
+    //   .await
+    //   .map_err(|e| {
+    //     println!("list bucket error: {:?}", e);
+    //     "list bucket error"
+    //   })?;
+    // let results = list
+    //   .into_iter()
+    //   .map(|item| {
+    //     let item_content = item.contents
+    //       .into_iter()
+    //       .map(|c| {
+    //         S3ListItemResponseContent {
+    //           last_modified: c.last_modified,
+    //           e_tag: c.e_tag,
+    //           storage_class: c.storage_class,
+    //           key: c.key,
+    //           size: c.size,
+    //         }
+    //       })
+    //       .collect::<Vec<_>>();
+    //     S3ListItemResponse {
+    //       name: item.name,
+    //       is_truncated: item.is_truncated,
+    //       prefix: item.prefix,
+    //       contents: item_content,
+    //     }
+    //   })
+    //   .collect::<Vec<_>>();
+    // Ok(results)
   }
 
-  pub fn create(&self, opts: &S3CreateOpts) -> Result<S3Response, &'static str> {
-    self.validate_config()?;
+  pub async fn create(&mut self, opts: &S3CreateOpts) -> Result<Vec<u8>, &'static str> {
+    let mut request = http::Request::builder()
+        .method("PUT")
+        .uri(format!("{}/{}", &opts.config.endpoint, opts.bucket_name))
+        .header("Accept", "application/json")
+        .body(Default::default())
+        .unwrap();
+
+    // sign the request
+    let _ = self.sign_request(&opts.config, &mut request)?;
+
+    // perform the request
+    let reqwest_request = reqwest::Request::try_from(request).unwrap();
+    let response = reqwest::Client::new()
+        .execute(reqwest_request)
+        .await
+        .map_err(|_| "failed to execute request")?;
+
+    if !response.status().is_success() {
+      return Err("failed to get response");
+    }
+
+    let got_text = response.text().await.map_err(|_| "failed to get response text")?;
+    Ok(got_text.as_bytes().to_vec())
+
+    // let bucket_config = BucketConfiguration::default();
+    //   BucketConfiguration {
+    //     acl: CannedBucketAcl::Private,
+    //     object_lock_enabled: false,
+    //     grant_full_control: None,
+    //     grant_read: None,
+    //     grant_read_acp: None,
+    //     grant_write: None,
+    //     grant_write_acp: None,
+    //     location_constraint: None,
+    // };
+    // let mut config = config;
+    // config.set_region(region.clone());
+    // let command = Command::CreateBucket { config };
+    // let bucket = Bucket::new(name, region, credentials)?;
+    // let request = RequestImpl::new(&bucket, "", command)?;
+    // let response_data = request.response_data(false).await?;
+    // let response_text = response_data.as_str()?;
+    // Ok(CreateBucketResponse {
+    //     bucket,
+    //     response_text: response_text.to_string(),
+    //     response_code: response_data.status_code(),
+    // })
+
+    // pub struct Reqwest<'a> {
+    //   pub bucket: &'a Bucket,
+    //   pub path: &'a str,
+    //   pub command: Command<'a>,
+    // }
+    
+    // let create_response = Bucket::create(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone(), bucket_config)
+    //   .await  
+    //   .map_err(|e| {
+    //     println!("create bucket error: {:?}", e);
+    //     "create bucket error"
+    //   })?;
+    // Ok(S3Response {
+    //   headers: Default::default(),
+    //   status_code: create_response.response_code,
+    //   bytes: create_response.response_text.as_bytes().to_vec(),
+    // })
+  }
+
+  pub async fn get(&self, opts: &S3GetOpts) -> Result<Vec<u8>, &'static str> {
+    // build the request to list objects in the S3 bucket
+    let mut request = http::Request::builder()
+        .method("GET")
+        .uri(format!("{}/{}?prefix={}", opts.config.endpoint, opts.bucket_name, opts.path))
+        .header("Accept", "application/json")
+        .body(Default::default())
+        .map_err(|_| "failed to build request")?;
+
+    // sign the request
+    let _ = self.sign_request(&opts.config, &mut request)?;
+
+    // perform the request
+    let reqwest_request = reqwest::Request::try_from(request).unwrap();
+    let response = reqwest::Client::new()
+        .execute(reqwest_request)
+        .await
+        .map_err(|_| "failed to execute request")?;
+
+    if !response.status().is_success() {
+      return Err("failed to get response");
+    }
+
+    let got_text = response.text().await.map_err(|_| "failed to get response text")?;
+    Ok(got_text.as_bytes().to_vec())
  
-    let bucket_config = BucketConfiguration::default();
-    let create_response = Bucket::create(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone(), bucket_config)
-      .map_err(|e| {
-        println!("create bucket error: {:?}", e);
-        "create bucket error"
-      })?;
-    Ok(S3Response {
-      headers: Default::default(),
-      status_code: create_response.response_code,
-      bytes: create_response.response_text.as_bytes().to_vec(),
-    })
+    // let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
+    //   .map_err(|e| {
+    //     println!("get bucket error: {:?}", e);
+    //     "bucket error"
+    //   })?;
+    // let get_response = bucket.get_object(&opts.path)
+    //   .await
+    //   .map_err(|e| {
+    //     println!("get object error: {:?}", e);
+    //     "get object error"
+    //   })?;
+    // Ok(S3Response {
+    //   status_code: get_response.status_code(),
+    //   headers: get_response.headers(),
+    //   bytes: get_response.to_vec(),
+    // })
   }
 
-  pub fn get(&self, opts: &S3GetOpts) -> Result<S3Response, &'static str> {
-    self.validate_config()?;
+  pub async fn put(&self, opts: &S3PutOpts) -> Result<Vec<u8>, &'static str> {
+    let mut request = http::Request::builder()
+        .method("PUT")
+        .uri(format!("{}/{}/{}", opts.config.endpoint, opts.bucket_name, opts.path))
+        .header("Accept", "application/json")
+        .header("Content-Type", "text/plain")
+        .header("Content-Length", opts.content.len().to_string())
+        .body(opts.content.clone())
+        .unwrap();
+
+     // sign the request
+     let _ = self.sign_request(&opts.config, &mut request)?;
+
+     // perform the request
+     let reqwest_request = reqwest::Request::try_from(request).unwrap();
+     let response = reqwest::Client::new()
+         .execute(reqwest_request)
+         .await
+         .map_err(|_| "failed to execute request")?;
  
-    let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
-      .map_err(|e| {
-        println!("get bucket error: {:?}", e);
-        "bucket error"
-      })?;
-    let get_response = bucket.get_object(&opts.path)
-      .map_err(|e| {
-        println!("get object error: {:?}", e);
-        "get object error"
-      })?;
-    Ok(S3Response {
-      status_code: get_response.status_code(),
-      headers: get_response.headers(),
-      bytes: get_response.to_vec(),
-    })
+     if !response.status().is_success() {
+       return Err("failed to get response");
+     }
+ 
+     let got_text = response.text().await.map_err(|_| "failed to get response text")?;
+     Ok(got_text.as_bytes().to_vec())
+
+    // let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
+    //   .map_err(|e| {
+    //     println!("put bucket error: {:?}", e);
+    //     "bucket error"
+    //   })?;
+    // let put_response = bucket.put_object(&opts.path, opts.content.as_slice())
+    //   .await
+    //   .map_err(|e| {
+    //     println!("put object error: {:?}", e);
+    //     "put object error"
+    //   })?;
+    // Ok(S3Response {
+    //   status_code: put_response.status_code(),
+    //   headers: put_response.headers(),
+    //   bytes: put_response.to_vec(),
+    // })
   }
 
-  pub fn put(&self, opts: &S3PutOpts) -> Result<S3Response, &'static str> {
-    self.validate_config()?;
+  pub async fn delete(&self, opts: &S3DeleteOpts) -> Result<Vec<u8>, &'static str> {
+    let mut request = http::Request::builder()
+        .method("DELETE")
+        .uri(format!("{}/{}/{}", opts.config.endpoint, opts.bucket_name, opts.path))
+        .header("Accept", "application/json")
+        .body(Default::default())
+        .unwrap();
 
-    let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
-      .map_err(|e| {
-        println!("put bucket error: {:?}", e);
-        "bucket error"
-      })?;
-    let put_response = bucket.put_object(&opts.path, opts.content.as_slice())
-      .map_err(|e| {
-        println!("put object error: {:?}", e);
-        "put object error"
-      })?;
-    Ok(S3Response {
-      status_code: put_response.status_code(),
-      headers: put_response.headers(),
-      bytes: put_response.to_vec(),
-    })
-  }
+     // sign the request
+     let _ = self.sign_request(&opts.config, &mut request)?;
 
-  pub fn delete(&self, opts: &S3DeleteOpts) -> Result<S3Response, &'static str> {
-    self.validate_config()?;
-  
-    let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
-      .map_err(|e| {
-        println!("delete bucket error: {:?}", e);
-        "bucket error"
-      })?;
-    let delete_response = bucket.delete_object(&opts.path)
-      .map_err(|e| {
-        println!("delete object error: {:?}", e);
-        "delete object error"
-      })?;
-    Ok(S3Response {
-      status_code: delete_response.status_code(),
-      headers: delete_response.headers(),
-      bytes: delete_response.to_vec(),
-    })
+     // perform the request
+     let reqwest_request = reqwest::Request::try_from(request).unwrap();
+     let response = reqwest::Client::new()
+         .execute(reqwest_request)
+         .await
+         .map_err(|_| "failed to execute request")?;
+ 
+     if !response.status().is_success() {
+       return Err("failed to get response");
+     }
+ 
+     let got_text = response.text().await.map_err(|_| "failed to get response text")?;
+     Ok(got_text.as_bytes().to_vec())
+
+    // let bucket = Bucket::new(&opts.bucket_name, self.region.as_ref().unwrap().clone(), self.credentials.as_ref().unwrap().clone())
+    //   .map_err(|e| {
+    //     println!("delete bucket error: {:?}", e);
+    //     "bucket error"
+    //   })?;
+    // let delete_response = bucket.delete_object(&opts.path)
+    //   .await
+    //   .map_err(|e| {
+    //     println!("delete object error: {:?}", e);
+    //     "delete object error"
+    //   })?;
+    // Ok(S3Response {
+    //   status_code: delete_response.status_code(),
+    //   headers: delete_response.headers(),
+    //   bytes: delete_response.to_vec(),
+    // })
   }
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub enum S3Command {
-  S3SetConfig(S3Config),
   S3Create(S3CreateOpts),
   S3List(S3ListOpts),
   S3Get(S3GetOpts),
@@ -169,21 +322,15 @@ pub enum S3Command {
 }
 impl_display!(S3Command);
 
+#[cfg(feature = "use-wasm-bindgen")]
 impl S3Command {
-  pub fn exec(&self, client: &mut S3Client) -> Result<Vec<u8>, &'static str> {
+  pub async fn exec(&self, client: &mut S3Client) -> Result<Vec<u8>, &'static str> {
     let res = match self {
-      S3Command::S3SetConfig(opts) => serde_json::to_vec(&client.set_config(opts.clone()))
-        .map_err(|_| "failed to serialize response")?,
-      S3Command::S3List(opts) => serde_json::to_vec(&client.list(opts.clone())?)
-        .map_err(|_| "failed to serialize response")?,
-      S3Command::S3Create(opts) => serde_json::to_vec(&client.create(opts)?)
-        .map_err(|_| "failed to serialize response")?,
-      S3Command::S3Get(opts) => serde_json::to_vec(&client.get(opts)?)
-        .map_err(|_| "failed to serialize response")?,
-      S3Command::S3Put(opts) => serde_json::to_vec(&client.put(opts)?)
-        .map_err(|_| "failed to serialize response")?,
-      S3Command::S3Delete(opts) => serde_json::to_vec(&client.delete(opts)?)
-        .map_err(|_| "failed to serialize response")?,
+      S3Command::S3List(opts) => client.list(opts.clone()).await?,
+      S3Command::S3Create(opts) => client.create(opts).await?,
+      S3Command::S3Get(opts) => client.get(opts).await?,
+      S3Command::S3Put(opts) => client.put(opts).await?,
+      S3Command::S3Delete(opts) => client.delete(opts).await?,
     };
     Ok(res)
   }
@@ -191,6 +338,8 @@ impl S3Command {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct S3ListOpts {
+  pub config: S3Config,
+
   pub bucket_name: String,
   pub prefix: String,
   pub delimiter: Option<String>,
@@ -215,17 +364,23 @@ pub struct S3ListItemResponse {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct S3CreateOpts {
+  pub config: S3Config,
+
   pub bucket_name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct S3GetOpts {
+  pub config: S3Config,
+
   pub bucket_name: String,
   pub path: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct S3PutOpts {
+  pub config: S3Config,
+
   pub bucket_name: String,
   pub path: String,
   pub content: Vec<u8>,
@@ -233,6 +388,8 @@ pub struct S3PutOpts {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct S3DeleteOpts {
+  pub config: S3Config,
+
   pub bucket_name: String,
   pub path: String,
 }
@@ -242,4 +399,201 @@ pub struct S3Response {
   bytes: Vec<u8>,
   status_code: u16,
   headers: HashMap<String, String>,
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  fn sign_request(req: &mut http::Request<&str>) {
+    let region = "us-east-1";
+    let aws_access_key = "test";
+    let aws_secret_key = "test";
+    
+    let signing_params = SigningParams::builder()
+      .access_key(aws_access_key)
+      .secret_key(aws_secret_key)
+      .region(region)
+      .service_name("s3")
+      .time(std::time::SystemTime::now())
+      .settings(SigningSettings::default())
+      .build()
+      .unwrap();
+
+    let signable_request = SignableRequest::from(&*req);
+    let (signing_instructions, _signature) = sign(signable_request, &signing_params).unwrap().into_parts();
+    signing_instructions.apply_to_request(req);
+  }
+
+  #[tokio::test]
+  async fn test_s3_list_buckets_localstack() {
+    let endpoint_url = "http://localhost:4566";
+    let mut request = http::Request::builder()
+      .method("GET")
+      .uri(endpoint_url)
+      .header("Accept", "application/json") 
+      .body("")
+      .unwrap();
+
+    sign_request(&mut request);
+
+    // perform the request
+    let reqwest_request = reqwest::Request::try_from(request).unwrap();
+    let response = reqwest::Client::new()
+      .execute(reqwest_request)
+      .await
+      .unwrap();
+
+    assert!(response.status().is_success());
+
+    let want_text= r#"<?xml version='1.0' encoding='utf-8'?>
+<ListAllMyBucketsResult><Owner><DisplayName>webfile</DisplayName><ID>75aa57f09aa0c8caeab4f8c24e99d10f8e7faeebf76c078efc7c6caea54ba06a</ID></Owner><Buckets /></ListAllMyBucketsResult>
+"#;
+
+    let got_text = response.text().await.unwrap();
+    assert_eq!(want_text, got_text);
+  }
+
+  #[tokio::test]
+  async fn test_s3_create_bucket_localstack() {
+    let endpoint_url = "http://localhost:4566";
+    let bucket_name = "my-new-bucket";
+
+    // Build the request to create a new S3 bucket
+    let mut request = http::Request::builder()
+        .method("PUT")
+        .uri(format!("{}/{}", endpoint_url, bucket_name))
+        .header("Accept", "application/json")
+        .body("")
+        .unwrap();
+
+    // Sign the request
+    sign_request(&mut request);
+
+    // Perform the request
+    let reqwest_request = reqwest::Request::try_from(request).unwrap();
+    let response = reqwest::Client::new()
+        .execute(reqwest_request)
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+  }
+
+  #[tokio::test]
+  async fn test_s3_list_objects_localstack() {
+    let endpoint_url = "http://localhost:4566";
+    let bucket_name = "my-new-bucket";
+    let path = "some/path"; // optional path/prefix
+
+    // Build the request to list objects in the S3 bucket
+    let mut request = http::Request::builder()
+        .method("GET")
+        .uri(format!("{}/{}?prefix={}", endpoint_url, bucket_name, path))
+        .header("Accept", "application/json")
+        .body("")
+        .unwrap();
+
+    // Sign the request
+    sign_request(&mut request);
+
+    // Perform the request
+    let reqwest_request = reqwest::Request::try_from(request).unwrap();
+    let response = reqwest::Client::new()
+        .execute(reqwest_request)
+        .await
+        .unwrap();
+
+    // Assert that the request is successful
+    assert!(response.status().is_success());
+
+    let got_text = response.text().await.unwrap();
+    assert_eq!("", got_text);
+  }
+
+  #[tokio::test]
+  async fn test_s3_put_object_localstack() {
+    let endpoint_url = "http://localhost:4566";
+    let bucket_name = "my-new-bucket";
+    let object_path = "some/path/to/new-object.txt";
+    let content = "This is the content to write.";
+
+    // Build the request to put an object into the S3 bucket
+    let mut request = http::Request::builder()
+        .method("PUT")
+        .uri(format!("{}/{}/{}", endpoint_url, bucket_name, object_path))
+        .header("Accept", "application/json")
+        .header("Content-Type", "text/plain")
+        .header("Content-Length", content.len().to_string())
+        .body(content)
+        .unwrap();
+
+    // Sign the request
+    sign_request(&mut request);
+
+    // Perform the request
+    let reqwest_request = reqwest::Request::try_from(request).unwrap();
+    let response = reqwest::Client::new()
+        .execute(reqwest_request)
+        .await
+        .unwrap();
+
+    // Assert that the request is successful
+    assert!(response.status().is_success());
+  }
+
+  #[tokio::test]
+  async fn test_s3_get_object_localstack() {
+    let endpoint_url = "http://localhost:4566";
+    let bucket_name = "my-new-bucket";
+    let object_path = "some/path/to/new-object.txt";
+
+    let mut request = http::Request::builder()
+        .method("GET")
+        .uri(format!("{}/{}/{}", endpoint_url, bucket_name, object_path))
+        .header("Accept", "application/json")
+        .body("")
+        .unwrap();
+
+    sign_request(&mut request);
+
+    let reqwest_request = reqwest::Request::try_from(request).unwrap();
+    let response = reqwest::Client::new()
+        .execute(reqwest_request)
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+
+    let got_content = response.text().await.unwrap();
+    assert_eq!(got_content, "This is the content to write.");
+  }
+
+  #[tokio::test]
+  async fn test_s3_delete_object_localstack() {
+    let endpoint_url = "http://localhost:4566";
+    let bucket_name = "my-new-bucket";
+    let object_path = "some/path/to/new-object.txt";
+
+    // Build the request to delete an object from the S3 bucket
+    let mut request = http::Request::builder()
+        .method("DELETE")
+        .uri(format!("{}/{}/{}", endpoint_url, bucket_name, object_path))
+        .header("Accept", "application/json")
+        .body("")
+        .unwrap();
+
+    // Sign the request
+    sign_request(&mut request);
+
+    // Perform the request
+    let reqwest_request = reqwest::Request::try_from(request).unwrap();
+    let response = reqwest::Client::new()
+        .execute(reqwest_request)
+        .await
+        .unwrap();
+
+    // Assert that the request is successful
+    assert!(response.status().is_success());
+  }
 }

--- a/crates/rust-sdk/Cargo.lock
+++ b/crates/rust-sdk/Cargo.lock
@@ -18,10 +18,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.36",
+]
+
+[[package]]
+name = "attohttpc"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
+dependencies = [
+ "http",
+ "log",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "aws-creds"
+version = "0.34.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3776743bb68d4ad02ba30ba8f64373f1be4e082fe47651767171ce75bb2f6cf5"
+dependencies = [
+ "attohttpc",
+ "dirs",
+ "log",
+ "quick-xml",
+ "rust-ini",
+ "serde",
+ "thiserror",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "aws-region"
+version = "0.25.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056557a61427d0e5ba29dd931031c8ffed4ee7a550e7cd55692a9d8deb0a9dba"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "backtrace"
@@ -40,15 +101,38 @@ dependencies = [
 
 [[package]]
 name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bls-common"
 version = "0.1.0"
 dependencies = [
+ "aws-creds",
  "reqwest",
+ "rust-s3",
  "serde",
  "serde_json",
  "serde_qs",
@@ -80,6 +164,72 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
 
 [[package]]
 name = "encoding_rs"
@@ -145,6 +295,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
 name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +345,24 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -287,6 +476,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "maybe-async"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,6 +550,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -362,12 +578,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -380,12 +612,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64",
+ "base64 0.21.4",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -412,6 +664,45 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if",
+ "ordered-multimap",
+]
+
+[[package]]
+name = "rust-s3"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2ac5ff6acfbe74226fa701b5ef793aaa054055c13ebb7060ad36942956e027"
+dependencies = [
+ "async-trait",
+ "attohttpc",
+ "aws-creds",
+ "aws-region",
+ "base64 0.13.1",
+ "bytes",
+ "cfg-if",
+ "hex",
+ "hmac",
+ "http",
+ "log",
+ "maybe-async",
+ "md5",
+ "percent-encoding",
+ "quick-xml",
+ "serde",
+ "serde_derive",
+ "sha2",
+ "thiserror",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -452,7 +743,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.36",
 ]
 
 [[package]]
@@ -490,6 +781,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +818,23 @@ checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -546,7 +865,36 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.36",
+]
+
+[[package]]
+name = "time"
+version = "0.3.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
+dependencies = [
+ "deranged",
+ "itoa",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ad70d68dba9e1f8aceda7aa6711965dfec1cac869f311a51bd08b3a2ccbce20"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]
@@ -624,6 +972,12 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
+
+[[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicase"
@@ -708,7 +1062,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.36",
  "wasm-bindgen-shared",
 ]
 
@@ -742,7 +1096,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.36",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/crates/rust-sdk/src/lib.rs
+++ b/crates/rust-sdk/src/lib.rs
@@ -212,18 +212,18 @@ pub fn dispatch_ipfs_call(module_call: IPFSCommand, callback_fn: fn(Result<Vec<u
 
 #[no_mangle]
 pub fn _start() {
-    // let req = HttpRequest::new("https://jsonplaceholder.typicode.com/todos/1", Method::Get);
-    // dispatch_http_call(req, |response| {
-    //     log!("http callback hit!");
-    //     log!("{:?}", response);
-    // });
-    let s3_command = S3Command::S3SetConfig(S3Config {
-        access_key: "".to_string(),
-        secret_key: "".to_string(),
-        endpoint: "".to_string(),
-        region: Some("".to_string()),
+    let config = S3Config {
+        access_key: "test".to_string(),
+        secret_key: "test".to_string(),
+        endpoint: "http://localhost:4566".to_string(),
+        region: None,
+    };
+    let s3_get = S3Command::S3Get(S3GetOpts {
+        config,
+        bucket_name: "my-new-bucket".to_string(),
+        path: "some/path/".to_string(),
     });
-    dispatch_s3_call(s3_command, |response| {
+    dispatch_s3_call(s3_get, |response| {
         log!("s3 callback hit!");
         let res_str = String::from_utf8(response.unwrap()).unwrap();
         log!("{:?}", res_str);

--- a/crates/rust-sdk/src/lib.rs
+++ b/crates/rust-sdk/src/lib.rs
@@ -3,6 +3,7 @@ use std::cell::{Cell, RefCell};
 
 use bls_common::{
     http::{Method, HttpRequest, HttpResponse},
+    s3::{S3Command, S3Config},
     ipfs::{IPFSCommand, FilesLsOpts},
 };
 
@@ -18,6 +19,12 @@ extern "C" {
 extern "C" {
     #[link_name = "http_call"]
     pub fn http_call(ptr: u32, len: u32, callback_id: u64) -> u32;
+}
+
+#[link(wasm_import_module = "blockless")]
+extern "C" {
+    #[link_name = "s3_call"]
+    pub fn s3_call(ptr: u32, len: u32, callback_id: u64) -> u32;
 }
 
 #[link(wasm_import_module = "blockless")]
@@ -73,6 +80,20 @@ pub fn http_callback(result_ptr: usize, callback_id: u64) -> *const u8 {
 }
 
 #[no_mangle]
+pub fn s3_callback(result_ptr: usize, callback_id: u64) -> *const u8 {
+    let serialized = decode_from_ptr(result_ptr);
+    let s3_call_response: Result<Vec<u8>, String> = serde_json::from_slice(&serialized[..]).unwrap(); // TODO: handle error
+
+    S3_CALLBACKS.with(|callbacks| {
+        if let Some(func) = callbacks.borrow_mut().remove(&callback_id) {
+            func(s3_call_response);
+        }
+    });
+
+    0 as *const u8
+}
+
+#[no_mangle]
 pub fn ipfs_callback(result_ptr: usize, callback_id: u64) -> *const u8 {
     let serialized = decode_from_ptr(result_ptr);
     let ipfs_call_response: Result<Vec<u8>, String> = serde_json::from_slice(&serialized[..]).unwrap(); // TODO: handle error
@@ -107,6 +128,7 @@ fn decode_from_ptr(result_ptr: usize) -> Vec<u8> {
 thread_local! {
     static NEXT_CALLBACK_ID: Cell<u64> = Cell::new(0);
     static HTTP_CALLBACKS: RefCell<HashMap<u64, fn(Result<HttpResponse, String>)>> = RefCell::new(HashMap::new());
+    static S3_CALLBACKS: RefCell<HashMap<u64, fn(Result<Vec<u8>, String>)>> = RefCell::new(HashMap::new());
     static IPFS_CALLBACKS: RefCell<HashMap<u64, fn(Result<Vec<u8>, String>)>> = RefCell::new(HashMap::new());
 }
 
@@ -124,6 +146,32 @@ pub fn dispatch_http_call(module_call: HttpRequest, callback_fn: fn(Result<HttpR
     let result_ptr = unsafe { http_call(ptr, len, callback_id) };
     if result_ptr == 0 {
         HTTP_CALLBACKS.with(|callbacks| {
+            callbacks.borrow_mut().insert(callback_id, callback_fn);
+        });
+        return Ok(());
+    }
+
+    let error_response = decode_from_ptr(result_ptr as usize);
+    let str_error_response = String::from_utf8(error_response).map_err(|_| "Failed to convert error response to string")?;
+
+    callback_fn(Err(str_error_response));
+    Ok(())
+}
+
+pub fn dispatch_s3_call(module_call: S3Command, callback_fn: fn(Result<Vec<u8>, String>)) -> Result<(), &'static str> {
+    let data = serde_json::to_vec(&module_call).map_err(|_| "Failed to serialize request")?;
+    let ptr = data.as_ptr() as u32;
+    let len = data.len() as u32;
+
+    let callback_id = NEXT_CALLBACK_ID.with(|id| {
+        let next_id = id.get() + 1;
+        id.set(next_id);
+        next_id
+    });
+
+    let result_ptr = unsafe { s3_call(ptr, len, callback_id) };
+    if result_ptr == 0 {
+        S3_CALLBACKS.with(|callbacks| {
             callbacks.borrow_mut().insert(callback_id, callback_fn);
         });
         return Ok(());
@@ -164,18 +212,29 @@ pub fn dispatch_ipfs_call(module_call: IPFSCommand, callback_fn: fn(Result<Vec<u
 
 #[no_mangle]
 pub fn _start() {
-    let req = HttpRequest::new("https://jsonplaceholder.typicode.com/todos/1", Method::Get);
-    dispatch_http_call(req, |response| {
-        log!("http callback hit!");
-        log!("{:?}", response);
+    // let req = HttpRequest::new("https://jsonplaceholder.typicode.com/todos/1", Method::Get);
+    // dispatch_http_call(req, |response| {
+    //     log!("http callback hit!");
+    //     log!("{:?}", response);
+    // });
+    let s3_command = S3Command::S3SetConfig(S3Config {
+        access_key: "".to_string(),
+        secret_key: "".to_string(),
+        endpoint: "".to_string(),
+        region: Some("".to_string()),
+    });
+    dispatch_s3_call(s3_command, |response| {
+        log!("s3 callback hit!");
+        let res_str = String::from_utf8(response.unwrap()).unwrap();
+        log!("{:?}", res_str);
     });
 
-    let files_ls = IPFSCommand::FilesLs(FilesLsOpts::default());
-    dispatch_ipfs_call(files_ls, |response| {
-        log!("ipfs callback hit!");
-        let response_str = String::from_utf8(response.unwrap()).unwrap();
-        log!("{:?}", response_str);
-    });
+    // let files_ls = IPFSCommand::FilesLs(FilesLsOpts::default());
+    // dispatch_ipfs_call(files_ls, |response| {
+    //     log!("ipfs callback hit!");
+    //     let response_str = String::from_utf8(response.unwrap()).unwrap();
+    //     log!("{:?}", response_str);
+    // });
 }
 
 


### PR DESCRIPTION
- S3 extension implementation
- Unfortunately could not use [rust-s3](https://github.com/durch/rust-s3) crate used by original blockless runtime - since it does not support wasm32 targets (browser runtime)
  - I tried quite a bit, but due to spending too much time on this and not getting support; decided to re-implement S3 extension/support using lower level HTTP REST API
    - using lower level aws s3 lib (https://crates.io/crates/aws-sigv4) - forked [here](https://github.com/blocklessnetwork/aws-sigv4-wasm32) for wasm32 support (to generate required AWS HTTP headers for requests)