### PR TITLE
Rust SDK custom async executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ docker run \
   -p 4510-4559:4510-4559 \
   localstack/localstack
 ```
+
+### IPFS
+
+Run local IPFS node (with CORS):
+```sh
+docker run --rm -it --name ipfs-node -p 4001:4001 -p 5001:5001 --entrypoint sh ipfs/go-ipfs:latest
+/usr/local/bin/start_ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[\"*\"]"
+/usr/local/bin/start_ipfs daemon --migrate=true --agent-version-suffix=docker
+```

--- a/bls-runtime-wasm/src/lib.rs
+++ b/bls-runtime-wasm/src/lib.rs
@@ -352,13 +352,16 @@ impl Blockless {
                     .into();
 
                 let http_call_response = match http_req.request().await {
-                    Ok(response) => HttpResponse::from_reqwest(response).await,
+                    Ok(response) => HttpResponse::from_reqwest(response)
+                        .await
+                        .map(|response| serde_json::to_vec(&response).map_err(|err| err.to_string()))
+                        .map_err(|err| err.to_string())
+                        .expect("failed to serialize module call response"),
                     Err(err) => {
                         console_error!("Error while running start function: {}", err);
                         Err(err.to_string())
                     }
                 };
-                console_log!("http_call: http_call_response: {:?}", http_call_response);
                 let data = serde_json::to_vec(&http_call_response).expect("failed to serialize module call response");
                 let result_ptr = utils::encode_data_to_memory(&memory_obj, &alloc_func, &data);
 

--- a/crates/bls-common/src/http.rs
+++ b/crates/bls-common/src/http.rs
@@ -117,7 +117,7 @@ impl_display!(HttpRequest);
 pub struct HttpResponse {
   pub status: u16,
   pub headers: HashMap<String, String>,
-  pub body: String,
+  pub body: Vec<u8>,
 }
 
 impl HttpResponse {
@@ -133,7 +133,7 @@ impl HttpResponse {
     Ok(HttpResponse {
       status,
       headers,
-      body: String::from_utf8(body.to_vec()).map_err(|_| "response body error")?,
+      body: body.to_vec(),
     })
   }
 }

--- a/crates/bls-common/src/ipfs.rs
+++ b/crates/bls-common/src/ipfs.rs
@@ -1,6 +1,5 @@
 
 use crate::{impl_display, impl_query_string_conversions};
-use crate::http::{HttpRequest, HttpResponse, Method};
 use std::str::FromStr;
 use serde::{Deserialize, Serialize};
 

--- a/crates/rust-sdk/Cargo.lock
+++ b/crates/rust-sdk/Cargo.lock
@@ -18,38 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
+name = "aho-corasick"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
 dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.73"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.36",
-]
-
-[[package]]
-name = "attohttpc"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcf00bc6d5abb29b5f97e3c61a90b6d3caa12f3faf897d4a3e3607c050a35a7"
-dependencies = [
- "http",
- "log",
- "serde",
- "serde_json",
- "url",
+ "memchr",
 ]
 
 [[package]]
@@ -59,29 +33,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "aws-creds"
-version = "0.34.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3776743bb68d4ad02ba30ba8f64373f1be4e082fe47651767171ce75bb2f6cf5"
+name = "aws-sigv4"
+version = "0.0.0-smithy-rs-head"
+source = "git+https://github.com/blocklessnetwork/aws-sigv4-wasm32?rev=61dd490d#61dd490db3886ae458897e2a3583bac5924e62d2"
 dependencies = [
- "attohttpc",
- "dirs",
- "log",
- "quick-xml",
- "rust-ini",
- "serde",
- "thiserror",
+ "aws-smithy-http",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "sha2",
  "time",
- "url",
+ "tracing",
+ "wasm-timer",
 ]
 
 [[package]]
-name = "aws-region"
-version = "0.25.3"
+name = "aws-smithy-http"
+version = "0.56.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "056557a61427d0e5ba29dd931031c8ffed4ee7a550e7cd55692a9d8deb0a9dba"
+checksum = "54cdcf365d8eee60686885f750a34c190e513677db58bbc466c44c588abf4199"
 dependencies = [
- "thiserror",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.56.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d90dbc8da2f6be461fa3c1906b20af8f79d14968fe47f2b7d29d086f62a51728"
+dependencies = [
+ "base64-simd",
+ "itoa",
+ "num-integer",
+ "ryu",
+ "serde",
+ "time",
 ]
 
 [[package]]
@@ -101,15 +102,19 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "bitflags"
@@ -130,12 +135,13 @@ dependencies = [
 name = "bls-common"
 version = "0.1.0"
 dependencies = [
- "aws-creds",
+ "aws-sigv4",
+ "http",
  "reqwest",
- "rust-s3",
  "serde",
  "serde_json",
  "serde_qs",
+ "wasm-timer",
 ]
 
 [[package]]
@@ -149,6 +155,16 @@ name = "bytes"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d3a8076e283f3acd27400535992edb3ba4b5bb72f8891ad8fbe7932a7d4b9"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cc"
@@ -191,7 +207,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f32d04922c60427da6f9fef14d042d9edddef64cb9d4ce0d64d0685fbeb1fd3"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -206,30 +221,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "4.0.0"
+name = "either"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
-]
-
-[[package]]
-name = "dlv-list"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "encoding_rs"
@@ -256,12 +251,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -269,6 +280,34 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -288,10 +327,16 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -302,17 +347,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
 ]
 
 [[package]]
@@ -345,9 +379,6 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-dependencies = [
- "ahash",
-]
 
 [[package]]
 name = "hex"
@@ -443,6 +474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,27 +510,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
-
-[[package]]
-name = "maybe-async"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f1b8c13cb1f814b634a96b2c725449fe7ed464a7b8781de8688be5ffbd3f305"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -535,6 +568,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,13 +602,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "ordered-multimap"
-version = "0.4.3"
+name = "outref"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+checksum = "4030760ffd992bef45b0ae3f10ce1aba99e33464c90d14dd7c039884963ddc7a"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
- "dlv-list",
- "hashbrown",
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -593,16 +666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-xml"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f50b1c63b38611e7d4d7f68b82d3ad0cc71a2ad2e7f61fc10f1328d917c93cd"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,15 +684,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
 dependencies = [
- "getrandom",
- "redox_syscall",
- "thiserror",
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
@@ -637,7 +718,7 @@ version = "0.11.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9ad3fe7488d7e34558a2033d45a0c90b72d97b4f80705666fea71472e2e6a1"
 dependencies = [
- "base64 0.21.4",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -667,49 +748,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-ini"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
-dependencies = [
- "cfg-if",
- "ordered-multimap",
-]
-
-[[package]]
-name = "rust-s3"
-version = "0.33.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b2ac5ff6acfbe74226fa701b5ef793aaa054055c13ebb7060ad36942956e027"
-dependencies = [
- "async-trait",
- "attohttpc",
- "aws-creds",
- "aws-region",
- "base64 0.13.1",
- "bytes",
- "cfg-if",
- "hex",
- "hmac",
- "http",
- "log",
- "maybe-async",
- "md5",
- "percent-encoding",
- "quick-xml",
- "serde",
- "serde_derive",
- "sha2",
- "thiserror",
- "time",
- "url",
-]
-
-[[package]]
 name = "rust-sdk"
 version = "0.1.0"
 dependencies = [
  "bls-common",
+ "futures",
  "serde",
  "serde_json",
 ]
@@ -725,6 +768,12 @@ name = "ryu"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -743,7 +792,7 @@ checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.36",
+ "syn",
 ]
 
 [[package]]
@@ -801,6 +850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "942b4a808e05215192e39f4ab80813e599068285906cc91aa64f923db842bd5a"
+
+[[package]]
 name = "socket2"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -825,17 +880,6 @@ name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
 
 [[package]]
 name = "syn"
@@ -865,7 +909,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.36",
+ "syn",
 ]
 
 [[package]]
@@ -875,7 +919,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a34ab300f2dee6e562c10a046fc05e358b29f9bf92277f30c3c8d82275f6f5"
 dependencies = [
  "deranged",
- "itoa",
  "powerfmt",
  "serde",
  "time-core",
@@ -955,7 +998,19 @@ checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1027,6 +1082,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1062,7 +1123,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.36",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1096,7 +1157,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.36",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1106,6 +1167,21 @@ name = "wasm-bindgen-shared"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+
+[[package]]
+name = "wasm-timer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "web-sys"

--- a/crates/rust-sdk/Cargo.lock
+++ b/crates/rust-sdk/Cargo.lock
@@ -753,6 +753,7 @@ version = "0.1.0"
 dependencies = [
  "bls-common",
  "futures",
+ "once_cell",
  "serde",
  "serde_json",
 ]

--- a/crates/rust-sdk/Cargo.toml
+++ b/crates/rust-sdk/Cargo.toml
@@ -12,5 +12,6 @@ crate-type = ["cdylib"]
 bls-common = { path = "../bls-common", default-features = false }
 
 futures = "0.3.28"
+once_cell = "1.18.0"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"

--- a/crates/rust-sdk/Cargo.toml
+++ b/crates/rust-sdk/Cargo.toml
@@ -11,5 +11,6 @@ crate-type = ["cdylib"]
 [dependencies]
 bls-common = { path = "../bls-common", default-features = false }
 
+futures = "0.3.28"
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.105"

--- a/crates/rust-sdk/src/executor.rs
+++ b/crates/rust-sdk/src/executor.rs
@@ -1,61 +1,37 @@
-use std::cell::RefCell;
-use std::future::Future;
-use std::task::{Poll, Context};
-use std::pin::Pin;
-use futures::{
-    channel::oneshot,
-    task::noop_waker,
+use std::{
+    cell::RefCell,
+    future::Future,
+    pin::Pin,
+    task::{Context, Waker},
 };
+use once_cell::sync::OnceCell;
 
 thread_local! {
-    pub static EXECUTOR: RefCell<Executor> = RefCell::new(Executor::new());
+    pub static EXECUTOR: RefCell<Executor> = RefCell::new(Executor::default());
 }
+
+#[derive(Default)]
 pub struct Executor {
-    tasks: Vec<Pin<Box<dyn Future<Output = ()>>>>,
+    task: OnceCell<Pin<Box<dyn Future<Output = ()>>>>,
 }
-
 impl Executor {
-    pub fn new() -> Self {
-        Self { tasks: vec![] }
-    }
-
-    pub fn spawn<F: Future<Output = ()> + 'static>(&mut self, future: F) {
-        self.tasks.push(Box::pin(future));
-        self.run();
-    }
-
-    pub fn spawn_with_result<F: Future<Output = T> + 'static, T: 'static>(&mut self, future: F) -> oneshot::Receiver<T> {
-        let (tx, rx) = oneshot::channel();
-
-        let wrapped_future = async {
-            let result = future.await;
-            let _ = tx.send(result);
-        };
-
-        self.spawn(wrapped_future);
-        rx
-    }
-
     pub fn run(&mut self) {
-        let waker = noop_waker();
-        let mut cx = Context::from_waker(&waker);
-
-        let mut i = 0;
-        while i < self.tasks.len() {
-            if let Poll::Ready(()) = self.tasks[i].as_mut().poll(&mut cx) {
-                // remove the task if it's done
-                self.tasks.swap_remove(i);
-            } else {
-                i += 1;
-            }
+        if let Some(ref mut task) = self.task.get_mut() {
+            let waker = Waker::noop();
+            let mut cx = Context::from_waker(&waker);
+            // Task is done, but we can't unset a OnceCell
+            // Do any cleanup or finalization here if needed
+            let _ = task.as_mut().poll(&mut cx);
         }
     }
 }
 
 pub fn spawn_local<F: Future<Output = ()> + 'static>(future: F) {
-    EXECUTOR.with(|executor| executor.borrow_mut().spawn(future));
+    EXECUTOR.with(|executor| {
+        let executor = &mut executor.borrow_mut();
+        let _ = executor.task.set(Box::pin(future));
+        executor.run();
+    });
 }
 
-pub fn spawn_local_with_result<F: Future<Output = T> + 'static, T: 'static>(future: F) -> oneshot::Receiver<T> {
-    EXECUTOR.with(|executor| executor.borrow_mut().spawn_with_result(future))
-}
+// TODO: macro to wrap start/main function

--- a/crates/rust-sdk/src/executor.rs
+++ b/crates/rust-sdk/src/executor.rs
@@ -1,0 +1,61 @@
+use std::cell::RefCell;
+use std::future::Future;
+use std::task::{Poll, Context};
+use std::pin::Pin;
+use futures::{
+    channel::oneshot,
+    task::noop_waker,
+};
+
+thread_local! {
+    pub static EXECUTOR: RefCell<Executor> = RefCell::new(Executor::new());
+}
+pub struct Executor {
+    tasks: Vec<Pin<Box<dyn Future<Output = ()>>>>,
+}
+
+impl Executor {
+    pub fn new() -> Self {
+        Self { tasks: vec![] }
+    }
+
+    pub fn spawn<F: Future<Output = ()> + 'static>(&mut self, future: F) {
+        self.tasks.push(Box::pin(future));
+        self.run();
+    }
+
+    pub fn spawn_with_result<F: Future<Output = T> + 'static, T: 'static>(&mut self, future: F) -> oneshot::Receiver<T> {
+        let (tx, rx) = oneshot::channel();
+
+        let wrapped_future = async {
+            let result = future.await;
+            let _ = tx.send(result);
+        };
+
+        self.spawn(wrapped_future);
+        rx
+    }
+
+    pub fn run(&mut self) {
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        let mut i = 0;
+        while i < self.tasks.len() {
+            if let Poll::Ready(()) = self.tasks[i].as_mut().poll(&mut cx) {
+                // remove the task if it's done
+                self.tasks.swap_remove(i);
+            } else {
+                i += 1;
+            }
+        }
+    }
+}
+
+pub fn spawn_local<F: Future<Output = ()> + 'static>(future: F) {
+    EXECUTOR.with(|executor| executor.borrow_mut().spawn(future));
+}
+
+pub fn spawn_local_with_result<F: Future<Output = T> + 'static, T: 'static>(future: F) -> oneshot::Receiver<T> {
+    EXECUTOR.with(|executor| executor.borrow_mut().spawn_with_result(future))
+}

--- a/crates/rust-sdk/src/lib.rs
+++ b/crates/rust-sdk/src/lib.rs
@@ -1,6 +1,12 @@
-use std::borrow::BorrowMut;
+#![feature(noop_waker)]
+
 use std::collections::HashMap;
 use std::cell::{Cell, RefCell};
+use std::fmt::Debug;
+use std::sync::atomic::AtomicU64;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use futures::channel::oneshot;
 
 use bls_common::{
     http::{Method, HttpRequest, HttpResponse},
@@ -70,7 +76,7 @@ pub unsafe fn dealloc(ptr: *mut u8, size: usize) {
 #[no_mangle]
 pub fn http_callback(result_ptr: usize, callback_id: u64) -> *const u8 {
     let serialized = decode_from_ptr(result_ptr);
-    let http_call_response: Result<HttpResponse, String> = serde_json::from_slice(&serialized[..]).unwrap(); // TODO: handle error
+    let http_call_response: Result<Vec<u8>, String> = serde_json::from_slice(&serialized[..]).unwrap(); // TODO: handle error
 
     PENDING_CALLS.with(|calls| {
         if let Some(sender) = calls.borrow_mut().remove(&callback_id) {
@@ -124,63 +130,53 @@ fn decode_from_ptr(result_ptr: usize) -> Vec<u8> {
     return serialized;
 }
 
+static NEXT_CALLBACK_ID: AtomicU64 = AtomicU64::new(0);
+
 // global mutable variables (since this is a single-threaded runtime)
 thread_local! {
-    static NEXT_CALLBACK_ID: Cell<u64> = Cell::new(0);
+    static PENDING_CALLS: RefCell<HashMap<u64, oneshot::Sender<Result<Vec<u8>, String>>>> = RefCell::new(HashMap::new());
     static S3_CALLBACKS: RefCell<HashMap<u64, fn(Result<Vec<u8>, String>)>> = RefCell::new(HashMap::new());
     static IPFS_CALLBACKS: RefCell<HashMap<u64, fn(Result<Vec<u8>, String>)>> = RefCell::new(HashMap::new());
-    static PENDING_CALLS: RefCell<HashMap<u64, oneshot::Sender<Result<HttpResponse, String>>>> = RefCell::new(HashMap::new());
 }
 
-use std::sync::Mutex;
-use std::sync::RwLock;
-
-use std::sync::Arc;
-use futures::Future;
-use futures::FutureExt;
-use futures::channel::oneshot;
-
-pub async fn dispatch_http_call_async(module_call: HttpRequest) -> Result<HttpResponse, String> {
+pub async fn dispatch_host_call<D: DeserializeOwned>(
+    data: impl Serialize,
+    host_call_fn: unsafe extern "C" fn(u32, u32, u64) -> u32,
+) -> Result<D, &'static str> {
     let (sender, receiver) = oneshot::channel();
 
-    let callback_id = NEXT_CALLBACK_ID.with(|id| {
-        let next_id = id.get() + 1;
-        id.set(next_id);
-        next_id
-    });
-
+    let callback_id = NEXT_CALLBACK_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     PENDING_CALLS.with(|calls| calls.borrow_mut().insert(callback_id, sender));
 
-    let data = serde_json::to_vec(&module_call).map_err(|_| "Failed to serialize request")?;
-    let ptr = data.as_ptr() as u32;
-    let len = data.len() as u32;
+    let data = serde_json::to_vec(&data).map_err(|_| "Failed to serialize request")?;
 
-    // Call the FFI function here.
-    let result_ptr = unsafe { http_call(ptr, len, callback_id) };
+    // Call the FFI function.
+    let result_ptr = unsafe { host_call_fn(data.as_ptr() as u32, data.len() as u32, callback_id) };
 
-    // If `result_ptr` is zero, then the call was successfully dispatched,
-    // and we expect a callback to `http_callback` function.
+    // If early return value is non-zero, an error must have ocurred in host runtime.
     if result_ptr != 0 {
-        Err("Failed to dispatch the HTTP call")?;
+        Err("Failed to dispatch the call")?;
     }
 
-    // If we reach here, it means the call was not successfully dispatched.
-    // You can handle this case as appropriate.
-
-    receiver.await.map_err(|_| "Failed to receive response")?
+    let response = receiver.await
+        .map_err(|_| "Failed to receive response")?
+        .map(|response| serde_json::from_slice::<D>(&response[..]).map_err(|_| "Failed to deserialize response"))
+        .map_err(|_| "Failed to deserialize response")?;
+    response
 }
+
+pub async fn dispatch_http_call(request: HttpRequest) -> Result<HttpResponse, &'static str> {
+    dispatch_host_call(request, http_call).await
+}
+
+// TODO: convert remaining methods to use dispatch_host_call
 
 pub fn dispatch_s3_call(module_call: S3Command, callback_fn: fn(Result<Vec<u8>, String>)) -> Result<(), &'static str> {
     let data = serde_json::to_vec(&module_call).map_err(|_| "Failed to serialize request")?;
     let ptr = data.as_ptr() as u32;
     let len = data.len() as u32;
 
-    let callback_id = NEXT_CALLBACK_ID.with(|id| {
-        let next_id = id.get() + 1;
-        id.set(next_id);
-        next_id
-    });
-
+    let callback_id = NEXT_CALLBACK_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     let result_ptr = unsafe { s3_call(ptr, len, callback_id) };
     if result_ptr == 0 {
         S3_CALLBACKS.with(|callbacks| {
@@ -201,11 +197,7 @@ pub fn dispatch_ipfs_call(module_call: IPFSCommand, callback_fn: fn(Result<Vec<u
     let ptr = data.as_ptr() as u32;
     let len = data.len() as u32;
 
-    let callback_id = NEXT_CALLBACK_ID.with(|id| {
-        let next_id = id.get() + 1;
-        id.set(next_id);
-        next_id
-    });
+    let callback_id = NEXT_CALLBACK_ID.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
     let result_ptr = unsafe { ipfs_call(ptr, len, callback_id) };
     if result_ptr == 0 {
@@ -220,6 +212,10 @@ pub fn dispatch_ipfs_call(module_call: IPFSCommand, callback_fn: fn(Result<Vec<u
 
     callback_fn(Err(str_error_response));
     Ok(())
+}
+
+async fn add(a: i32, b: i32) -> i32 {
+    a + b
 }
 
 #[no_mangle]
@@ -242,31 +238,34 @@ pub fn _start() {
     // });
 
     executor::spawn_local(async {
-        let response1 = dispatch_http_call_async(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/1", Method::Get)).await;
+        let sum = add(1, 5).await;
+        log!("sum: {}", sum);
+        
+        let response1 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/1", Method::Get)).await;
         log!("First http callback hit!");
         log!("{:?}", response1);
 
-        let response2 = dispatch_http_call_async(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/2", Method::Get)).await;
+        let response2 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/2", Method::Get)).await;
         log!("Second http callback hit!");
         log!("{:?}", response2);
 
-        let response3 = dispatch_http_call_async(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/3", Method::Get)).await;
+        let response3 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/3", Method::Get)).await;
         log!("Third http callback hit!");
         log!("{:?}", response3);
 
-        let response4 = dispatch_http_call_async(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/4", Method::Get)).await;
+        let response4 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/4", Method::Get)).await;
         log!("Fourth http callback hit!");
         log!("{:?}", response4);
 
-        let response5 = dispatch_http_call_async(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/5", Method::Get)).await;
+        let response5 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/5", Method::Get)).await;
         log!("Fifth http callback hit!");
         log!("{:?}", response5);
 
-        let response6 = dispatch_http_call_async(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/6", Method::Get)).await;
+        let response6 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/6", Method::Get)).await;
         log!("Sixth http callback hit!");
         log!("{:?}", response6);
 
-        let response7 = dispatch_http_call_async(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/7", Method::Get)).await;
+        let response7 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/7", Method::Get)).await;
         log!("Seventh http callback hit!");
         log!("{:?}", response7);
     });

--- a/crates/rust-sdk/src/lib.rs
+++ b/crates/rust-sdk/src/lib.rs
@@ -179,90 +179,34 @@ pub async fn dispatch_ipfs_call(request: IPFSCommand) -> Result<Vec<u8>, &'stati
 #[no_mangle]
 pub fn _start() {
     executor::spawn_local(async {
-        let files_ls = IPFSCommand::FilesLs(FilesLsOpts::default());
-        let result = dispatch_ipfs_call(files_ls).await;
-        log!("ipfs callback hit!");
-        let res_str = String::from_utf8(result.unwrap()).unwrap();
-        log!("{:?}", res_str);
+        let response1 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/1", Method::Get)).await;
+        log!("First http callback hit!");
+        log!("{:?}", response1);
+
+        let response2 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/2", Method::Get)).await;
+        log!("Second http callback hit!");
+        log!("{:?}", response2);
+
+        let response3 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/3", Method::Get)).await;
+        log!("Third http callback hit!");
+        log!("{:?}", response3);
+
+        let response4 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/4", Method::Get)).await;
+        log!("Fourth http callback hit!");
+        log!("{:?}", response4);
+
+        let response5 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/5", Method::Get)).await;
+        log!("Fifth http callback hit!");
+        log!("{:?}", response5);
+
+        let response6 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/6", Method::Get)).await;
+        log!("Sixth http callback hit!");
+        log!("{:?}", response6);
+
+        let response7 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/7", Method::Get)).await;
+        log!("Seventh http callback hit!");
+        log!("{:?}", response7);
     });
-
-    // executor::spawn_local(async {
-    //     let config = S3Config {
-    //         access_key: "test".to_string(),
-    //         secret_key: "test".to_string(),
-    //         endpoint: "http://localhost:4566".to_string(),
-    //         region: None,
-    //     };
-
-    //     let result = dispatch_s3_call(S3Command::S3Create(S3CreateOpts {
-    //         config: config.clone(),
-    //         bucket_name: "my-new-bucket".to_string(),
-    //     })).await;
-    //     log!("s3 S3Create callback hit!");
-    //     let res_str = String::from_utf8(result.unwrap()).unwrap();
-    //     log!("{:?}", res_str);
-
-    //     let result = dispatch_s3_call(S3Command::S3Put(S3PutOpts {
-    //         config: config.clone(),
-    //         bucket_name: "my-new-bucket".to_string(),
-    //         path: "some/path/hello.txt".to_string(),
-    //         content: "hello world".as_bytes().to_vec(),
-    //     })).await;
-    //     log!("s3 S3Put callback hit!");
-    //     let res_str = String::from_utf8(result.unwrap()).unwrap();
-    //     log!("{:?}", res_str);
-
-    //     let result = dispatch_s3_call(S3Command::S3Get(S3GetOpts {
-    //         config: config.clone(),
-    //         bucket_name: "my-new-bucket".to_string(),
-    //         path: "some/path/hello.txt".to_string(),
-    //     })).await;
-    //     log!("s3 S3Get callback hit!");
-    //     let res_str = String::from_utf8(result.unwrap()).unwrap();
-    //     log!("{:?}", res_str);
-
-    //     let result = dispatch_s3_call(S3Command::S3Delete(S3DeleteOpts {
-    //         config,
-    //         bucket_name: "my-new-bucket".to_string(),
-    //         path: "some/path/hello.txt".to_string(),
-    //     })).await;
-    //     log!("s3 S3Delete callback hit!");
-    //     let res_str = String::from_utf8(result.unwrap()).unwrap();
-    //     log!("{:?}", res_str);
-    // });
-        
-    // executor::spawn_local(async {
-    //     let sum = add(1, 5).await;
-    //     log!("sum: {}", sum);
-        
-    //     let response1 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/1", Method::Get)).await;
-    //     log!("First http callback hit!");
-    //     log!("{:?}", response1);
-
-    //     let response2 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/2", Method::Get)).await;
-    //     log!("Second http callback hit!");
-    //     log!("{:?}", response2);
-
-    //     let response3 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/3", Method::Get)).await;
-    //     log!("Third http callback hit!");
-    //     log!("{:?}", response3);
-
-    //     let response4 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/4", Method::Get)).await;
-    //     log!("Fourth http callback hit!");
-    //     log!("{:?}", response4);
-
-    //     let response5 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/5", Method::Get)).await;
-    //     log!("Fifth http callback hit!");
-    //     log!("{:?}", response5);
-
-    //     let response6 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/6", Method::Get)).await;
-    //     log!("Sixth http callback hit!");
-    //     log!("{:?}", response6);
-
-    //     let response7 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/7", Method::Get)).await;
-    //     log!("Seventh http callback hit!");
-    //     log!("{:?}", response7);
-    // });
 }
 
 
@@ -287,23 +231,44 @@ mod tests {
         log!("{:?}", args);
     }
 
-    // #[test]
-    // fn test_http_call() {
-    //     let req = HttpRequest::new("https://jsonplaceholder.typicode.com/todos/1", Method::Get);
-    //     dispatch_http_call(req, |response| {
-    //         log!("callback hit!");
-    //         log!("{:?}", response);
-    //     });
-    // }
+    // TODO: convert to example since cant test in this environment
+    #[test]
+    fn test_http_call() {
+        executor::spawn_local(async {
+            let response = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/1", Method::Get)).await;
+            log!("First http callback hit!");
+            log!("{:?}", response);
+        });
+    }
 
+    // TODO: convert to example since cant test in this environment
+    #[test]
+    fn test_s3_call() {
+        executor::spawn_local(async {
+            let result = dispatch_s3_call(S3Command::S3Create(S3CreateOpts {
+                config: S3Config {
+                    access_key: "test".to_string(),
+                    secret_key: "test".to_string(),
+                    endpoint: "http://localhost:4566".to_string(),
+                    region: None,
+                },
+                bucket_name: "my-new-bucket".to_string(),
+            })).await;
+            log!("s3 S3Create callback hit!");
+            let res_str = String::from_utf8(result.unwrap()).unwrap();
+            log!("{:?}", res_str);
+        });
+    }
+
+    // TODO: convert to example since cant test in this environment
     #[test]
     fn test_ipfs_call() {
-        let files_ls = IPFSCommand::FilesLs(FilesLsOpts::default());
-        dispatch_ipfs_call(files_ls, |response| {
-            log!("ipfs callback hit!");
-            let response_str = String::from_utf8(response.unwrap()).unwrap();
-            log!("{:?}", response_str);
-        });
+        executor::spawn_local(async {
+            let files_ls = IPFSCommand::FilesLs(FilesLsOpts::default());
+            let result = dispatch_ipfs_call(files_ls).await;
+            let res_str = String::from_utf8(result.unwrap()).unwrap();
+            log!("{:?}", res_str);
+        });  
     }
 
     #[test]

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,13 @@ const bls = new Blockless({
     // "entry": "lib.wasm",
     permissions: [
         "https://jsonplaceholder.typicode.com/todos/1",
+        "https://jsonplaceholder.typicode.com/todos/2",
+        "https://jsonplaceholder.typicode.com/todos/3",
+        "https://jsonplaceholder.typicode.com/todos/4",
+        "https://jsonplaceholder.typicode.com/todos/5",
+        "https://jsonplaceholder.typicode.com/todos/6",
+        "https://jsonplaceholder.typicode.com/todos/7",
+        "https://jsonplaceholder.typicode.com/todos/8",
         "http://httpbin.org/anything",
         "file://a.go"
     ],


### PR DESCRIPTION
# Context
No more callback hell!

Improvements of the Rust SDK to support `async`-`await` - via **custom async executor**
- This is required since you encounter callback hell when chaining calls to blockless extensions (calling host runtime) - which significantly deteriorates the development experience
- This should be a good quality of life change for users wanting to use the rust-sdk 
- Implementation of minimal async runtime for `wasm32-unknown-unknown` and `wasm32-wasi` compilation targets (our rust SDK)

## Example usage
```rust
executor::spawn_local(async {
            let response = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/1", Method::Get)).await;
            log!("1st http callback hit!");
            log!("{:?}", response);

            let response2 = dispatch_http_call(HttpRequest::new("https://jsonplaceholder.typicode.com/todos/2", Method::Get)).await;
            log!("2nd http callback hit!");
            log!("{:?}", response2);
});
```

The code will wait for each of the operations before executing.
This should increase `rust-sdk` interoperability with other crates and async primitives.

## Screenshots

**`rust-sdk` code:**
<img width="1139" alt="image" src="https://github.com/blocklessnetwork/bls-runtime-js/assets/63374656/11d7164f-b921-4e08-943d-0325d6b078c8">

**browser result:**
<img width="1485" alt="image" src="https://github.com/blocklessnetwork/bls-runtime-js/assets/63374656/dffa067f-36e2-40e6-a9e2-27d7c7d223ca">
